### PR TITLE
Add proof-of-concept register function to setup project structure

### DIFF
--- a/chrysalis/__init__.py
+++ b/chrysalis/__init__.py
@@ -1,0 +1,1 @@
+from chrysalis._internal._controller import register as register

--- a/chrysalis/_internal/_controller.py
+++ b/chrysalis/_internal/_controller.py
@@ -1,0 +1,5 @@
+_KNOWLEDGE_BASE: list[str] = []
+
+
+def register(s: str) -> None:
+    _KNOWLEDGE_BASE.append(s)

--- a/chrysalis/_internal/_controller_test.py
+++ b/chrysalis/_internal/_controller_test.py
@@ -1,0 +1,8 @@
+from chrysalis._internal import _controller as controller
+
+
+def test_register_string() -> None:
+    controller.register("hello")
+    controller.register("world")
+
+    assert " ".join(controller._KNOWLEDGE_BASE) == "hello world"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,16 +33,12 @@ path = "chrysalis/__about__.py"
 installer = "uv"
 
 [tool.hatch.envs.ci]
-extra-dependencies = [
-  "mypy>=1.0.0",
-]
+extra-dependencies = ["mypy>=1.0.0"]
 [tool.hatch.envs.ci.scripts]
-check = [
-    "mypy --install-types --non-interactive {args:chrysalis tests}",
-]
+check = ["mypy --install-types --non-interactive {args:chrysalis tests}"]
 
 [tool.ruff.lint]
-ignore = ["T201"]
+ignore = ["T201", "PLC0414", "S101", "SLF001"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["chrysalis"]
@@ -51,17 +47,11 @@ known-first-party = ["chrysalis"]
 source_pkgs = ["chrysalis", "tests"]
 branch = true
 parallel = true
-omit = [
-  "chrysalis/__about__.py",
-]
+omit = ["chrysalis/__about__.py"]
 
 [tool.coverage.paths]
 chrysalis = ["chrysalis", "*/chrysalis/chrysalis"]
 tests = ["tests", "*/chrysalis/tests"]
 
 [tool.coverage.report]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
-]
+exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]


### PR DESCRIPTION
The `register` function will adapted later as the main entry point for registering relations.

Note the current project directory structure:
```
.
├── LICENSE
├── README.md
├── chrysalis
│   ├── __about__.py
│   ├── __init__.py
│   ├── __pycache__
│   │   └── __init__.cpython-313.pyc
│   └── _internal
│       ├── __init__.py
│       ├── __pycache__
│       │   ├── _controller_test.cpython-313-pytest-8.3.4.pyc
│       │   └── _engine.cpython-313.pyc
│       ├── _controller.py
│       └── _controller_test.py
├── dist
├── pyproject.toml
└── tests
    └── __init__.py

7 directories, 12 files
```